### PR TITLE
Align kernel URL for server with client kernel URL (#1509)

### DIFF
--- a/packages/kernel/src/kernels.ts
+++ b/packages/kernel/src/kernels.ts
@@ -1,6 +1,6 @@
 import { ObservableMap } from '@jupyterlab/observables';
 
-import { Kernel, KernelMessage } from '@jupyterlab/services';
+import { KernelAPI, Kernel, KernelMessage } from '@jupyterlab/services';
 
 import { deserialize, serialize } from '@jupyterlab/services/lib/kernel/serialize';
 
@@ -14,7 +14,7 @@ import { IKernel, IKernels, IKernelSpecs } from './tokens';
 
 import { Mutex } from 'async-mutex';
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 
 /**
  * Use the default kernel wire protocol.
@@ -118,7 +118,12 @@ export class Kernels implements IKernels {
     const kernelId = id ?? UUID.uuid4();
 
     // There is one server per kernel which handles multiple clients
-    const kernelUrl = `${Kernels.WS_BASE_URL}api/kernels/${kernelId}/channels`;
+    const kernelUrl = URLExt.join(
+      Kernels.WS_BASE_URL,
+      KernelAPI.KERNEL_SERVICE_URL,
+      encodeURIComponent(kernelId),
+      'channels',
+    );
     const runningKernel = this._kernels.get(kernelId);
     if (runningKernel) {
       return {


### PR DESCRIPTION
* Align kernel URL for server with client kernel URL

* Lint the code

---------

<!--
Thanks for contributing to JupyterLite!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/jupyterlite/jupyterlite/blob/main/CONTRIBUTING.md
-->

## References

<!-- Note issue numbers this pull request addresses (should be at least one, see contributing guidelines above). -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!-- For visual changes, include before and after screenshots here. -->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to JupyterLite public APIs. -->

## Summary by Sourcery

Enhancements:
- Align the server kernel URL with the client kernel URL for consistency.